### PR TITLE
Fix panic when condition value is unknown

### DIFF
--- a/internal/evaluator/eval.go
+++ b/internal/evaluator/eval.go
@@ -129,11 +129,16 @@ func (e *Evaluator) evaluateCondition(ctx *hcl.EvalContext, content *hcl.BodyCon
 		if val.Type() != cty.Bool {
 			return false, diags.Append(hclutils.Err2Diag(fmt.Errorf("got type %s, expected %s", val.Type(), cty.Bool)))
 		}
-		shouldDiscard := !val.IsKnown()
-		if !shouldDiscard {
-			shouldDiscard = !val.True()
+		if !val.IsKnown() {
+			e.discard(DiscardItem{
+				Type:        et,
+				Reason:      discardReasonIncomplete,
+				Name:        name,
+				SourceRange: condAttr.Range.String(),
+			})
+			return false, diags
 		}
-		if shouldDiscard {
+		if !val.True() {
 			e.discard(DiscardItem{
 				Type:        et,
 				Reason:      discardReasonUserCondition,

--- a/internal/evaluator/eval.go
+++ b/internal/evaluator/eval.go
@@ -123,7 +123,7 @@ func (e *Evaluator) toContent(files []File) (*hcl.BodyContent, hcl.Diagnostics) 
 func (e *Evaluator) evaluateCondition(ctx *hcl.EvalContext, content *hcl.BodyContent, et DiscardType, name string) (bool, hcl.Diagnostics) {
 	if condAttr, exists := content.Attributes[attrCondition]; exists {
 		val, diags := condAttr.Expr.Value(ctx)
-		if diags.HasErrors() {
+		if diags.HasErrors() || !val.IsKnown() {
 			return false, diags
 		}
 		if val.Type() != cty.Bool {

--- a/internal/evaluator/eval_test.go
+++ b/internal/evaluator/eval_test.go
@@ -89,6 +89,17 @@ func TestPositiveEval(t *testing.T) {
 				}
 			`,
 		},
+		{
+			name: "incomplete conditions allowed",
+			hcl: `
+				locals {
+				  foo = "${req.resources.primary_bucket.status.arn}"
+				}
+				group {
+				  condition = can(foo)
+				}
+			`,
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/evaluator/requirements_test.go
+++ b/internal/evaluator/requirements_test.go
@@ -149,6 +149,20 @@ requirement cm {
 }
 `,
 		},
+		{
+			name: "bad condition",
+			hcl: `
+requirement cm {
+	condition = req.foo
+	select {
+		apiVersion = "v1"
+		kind = "ConfigMap"
+		matchLabels = { "foo": "bar" }
+	}
+}
+`,
+			msg: `test.hcl:3,17-21: Unsupported attribute; This object does not have an attribute named "foo"`,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -279,20 +293,6 @@ requirement cm {
 }
 `,
 			msg: `test.hcl:4,9-12: reference to non-existent variable; foo`,
-		},
-		{
-			name: "bad condition",
-			hcl: `
-requirement cm {
-	condition = req.foo
-	select {
-		apiVersion = "v1"
-		kind = "ConfigMap"
-		matchLabels = { "foo": "bar" }
-	}
-}
-`,
-			msg: `test.hcl:3,17-21: Unsupported attribute; This object does not have an attribute named "foo"`,
 		},
 		{
 			name: "bad type apiVersion",

--- a/spec.md
+++ b/spec.md
@@ -243,7 +243,7 @@ You can have conditions for individual resources, resource lists, and groups.
 
 ```hcl
 // The resource block can have an optional condition attribute that is an expression which must evaluate to a 
-// boolean value. Incomplete values are not allowed here. Use `try` and `can` if something could be missing.
+// boolean value. Incomplete values are allowed and treated as false. Use `try` and `can` if something could be missing.
 resource s3_acl {
     condition = try(req.composite.spec.parameters.createAcls, true) // defaults to true if unspecified
     body {


### PR DESCRIPTION
We currently assume that if the diagnostic has no error, it's possible to read the value of a condition expression. When the value is unknown, a panic is triggered by `cty.True()` as this function doesn't work with unknown values.

The fix changes the semantic, incomplete values are now allowed and treated as `false`.

Added a test case that panics without the fix.