### PR TITLE
initialize unknown function args to DynamicVal, fixes #28

### DIFF
--- a/internal/evaluator/functions/load.go
+++ b/internal/evaluator/functions/load.go
@@ -132,7 +132,7 @@ func (e *Processor) processArg(fn string, block *hcl.Block) (*Arg, hcl.Diagnosti
 	}
 
 	defAttr := a.Attributes[attrDefault]
-	var v cty.Value
+	v := cty.DynamicVal
 	if defAttr != nil {
 		v, diags = defAttr.Expr.Value(&hcl.EvalContext{})
 		curDiags = curDiags.Extend(diags)


### PR DESCRIPTION
Explicitly initialize function arguments without a default value to `cty.DynamicVal`. This fixes the panic observed in #28