### PR TITLE
use latest go version for coverage

### DIFF
--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -14,7 +14,7 @@ jobs:
         with:
           fetch-depth: "0"
       - id: go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: 1.23
       - name: run tests


### PR DESCRIPTION
Otherwise coverage breaks because a tool is not found.