### PR TITLE
pkg: switch Function package APIs from v1beta1 to v1

### DIFF
--- a/package/crossplane.yaml
+++ b/package/crossplane.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: meta.pkg.crossplane.io/v1beta1
+apiVersion: meta.pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: function-hcl


### PR DESCRIPTION
### Description

This PR updates Function package manifests to use `v1` instead of `v1beta1` for:

- `meta.pkg.crossplane.io`
- `pkg.crossplane.io`

Both `Function` and `FunctionRevision` already use `v1` as their storage version, so this change does not affect existing Crossplane installations when  Crossplane >= 1.17.x

The change only impacts newly built function packages, which will now be published using `v1`. Installing or upgrading these packages in an existing control plane works without disruption.

Related issue: https://github.com/crossplane/crossplane/issues/6947