### PR TITLE
go back to using upstream hcl after PR merge

### DIFF
--- a/language-server/README.md
+++ b/language-server/README.md
@@ -32,10 +32,3 @@ point. A lot of refactoring has been done on both these copied codebases to make
 work for function-hcl. Both upstream projects are licensed under the Mozilla Public License 2.0 (MPL-2.0).
 See [NOTICE](NOTICE) for specific attribution details and [LICENSE-MPL-2.0.txt](LICENSE-MPL-2.0.txt)
 for the full license text.
-
-In addition, the `go.mod` replaces the [HCL dependency](https://github.com/hashicorp/hcl) 
-with a [fork](https://github.com/gotwarlost/hcl) because of a [critical fix](https://github.com/hashicorp/hcl/pull/785) 
-for a [known issue](https://github.com/hashicorp/hcl/issues/597) that is needed.
-
-You cannot build this repo using `go install github.com/...` because of this. For source builds, you will need to clone 
-the repo and build it locally.

--- a/language-server/go.mod
+++ b/language-server/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/google/go-containerregistry v0.20.7
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.7.0
-	github.com/hashicorp/hcl/v2 v2.24.0
+	github.com/hashicorp/hcl/v2 v2.24.1-0.20260327001625-d4195a120f30
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/spf13/cobra v1.10.2
@@ -25,8 +25,6 @@ require (
 	k8s.io/apiextensions-apiserver v0.34.2
 	k8s.io/apimachinery v0.35.0
 )
-
-replace github.com/hashicorp/hcl/v2 => github.com/gotwarlost/hcl/v2 v2.0.0-20260210011329-0927384ef641
 
 require (
 	dario.cat/mergo v1.0.2 // indirect

--- a/language-server/go.sum
+++ b/language-server/go.sum
@@ -119,12 +119,14 @@ github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 h1:BHT72Gu3keYf3ZEu2J
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/gotwarlost/hcl/v2 v2.0.0-20260210011329-0927384ef641 h1:+EvCvuVKbVO3HwxCbcujmOAvQSUY+1I4RQ5NHqLToX4=
-github.com/gotwarlost/hcl/v2 v2.0.0-20260210011329-0927384ef641/go.mod h1:WS1ymNdBhhwYKDVlGnUb9fmqB2hw1djJva6S8Bj/WfI=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKeRZfjY=
 github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/hcl/v2 v2.24.0 h1:2QJdZ454DSsYGoaE6QheQZjtKZSUs9Nh2izTWiwQxvE=
+github.com/hashicorp/hcl/v2 v2.24.0/go.mod h1:oGoO1FIQYfn/AgyOhlg9qLC6/nOJPX3qGbkZpYAcqfM=
+github.com/hashicorp/hcl/v2 v2.24.1-0.20260327001625-d4195a120f30 h1:IQMtUW+S2J6QFXpd+hMrMJmGMElL1/2VrixOkjCmmkk=
+github.com/hashicorp/hcl/v2 v2.24.1-0.20260327001625-d4195a120f30/go.mod h1:WS1ymNdBhhwYKDVlGnUb9fmqB2hw1djJva6S8Bj/WfI=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=

--- a/language-server/go.sum
+++ b/language-server/go.sum
@@ -123,8 +123,6 @@ github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/C
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKeRZfjY=
 github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
-github.com/hashicorp/hcl/v2 v2.24.0 h1:2QJdZ454DSsYGoaE6QheQZjtKZSUs9Nh2izTWiwQxvE=
-github.com/hashicorp/hcl/v2 v2.24.0/go.mod h1:oGoO1FIQYfn/AgyOhlg9qLC6/nOJPX3qGbkZpYAcqfM=
 github.com/hashicorp/hcl/v2 v2.24.1-0.20260327001625-d4195a120f30 h1:IQMtUW+S2J6QFXpd+hMrMJmGMElL1/2VrixOkjCmmkk=
 github.com/hashicorp/hcl/v2 v2.24.1-0.20260327001625-d4195a120f30/go.mod h1:WS1ymNdBhhwYKDVlGnUb9fmqB2hw1djJva6S8Bj/WfI=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=


### PR DESCRIPTION
Now that https://github.com/hashicorp/hcl/pull/785 has been merged, we can use that commit instead of using the fork